### PR TITLE
build virtualenv with configured python version

### DIFF
--- a/readthedocs_build/builder/base.py
+++ b/readthedocs_build/builder/base.py
@@ -17,8 +17,7 @@ class BaseBuilder(object):
 
     def setup_virtualenv(self):
         python_config = self.build_config['python']
-        use_system_site_packages = python_config['use_system_site_packages']
-        self.venv = VirtualEnv(system_site_packages=use_system_site_packages)
+        self.venv = VirtualEnv(python_config)
         for package in self.python_dependencies:
             self.venv.install(package)
         if python_config['setup_py_install']:

--- a/readthedocs_build/builder/test_base.py
+++ b/readthedocs_build/builder/test_base.py
@@ -77,7 +77,7 @@ def describe_setup_virtualenv():
         with patch('readthedocs_build.builder.base.VirtualEnv') as VirtualEnv:
             builder = BaseBuilder(build_config=build_config)
             builder.setup_virtualenv()
-            VirtualEnv.assert_called_with(system_site_packages=False)
+            VirtualEnv.assert_called_with(build_config['python'])
 
         build_config = get_config()
         build_config['python'].update({
@@ -86,7 +86,7 @@ def describe_setup_virtualenv():
         with patch('readthedocs_build.builder.base.VirtualEnv') as VirtualEnv:
             builder = BaseBuilder(build_config=build_config)
             builder.setup_virtualenv()
-            VirtualEnv.assert_called_with(system_site_packages=True)
+            VirtualEnv.assert_called_with(build_config['python'])
 
     def it_executes_setup_py_install(tmpdir):
         setup_py = str(tmpdir.join('setup.py'))

--- a/readthedocs_build/builder/test_virtualenv.py
+++ b/readthedocs_build/builder/test_virtualenv.py
@@ -21,7 +21,11 @@ def test_it_respects_system_site_packages_flag():
     with patch('readthedocs_build.builder.virtualenv.run') as run:
         run.return_value = 0
 
-        venv = VirtualEnv(system_site_packages=True)
+        python_config = {
+            'use_system_site_packages': True,
+        }
+
+        venv = VirtualEnv(python_config)
         assert venv.system_site_packages
         run.assert_called_with([
             'virtualenv',

--- a/readthedocs_build/builder/virtualenv.py
+++ b/readthedocs_build/builder/virtualenv.py
@@ -10,9 +10,14 @@ class VirtualEnv(object):
     Light abstraction of a virtualenv.
     """
 
-    def __init__(self, system_site_packages=False):
+    def __init__(self, python_config=None):
         self.base_path = tempfile.mkdtemp()
-        self.system_site_packages = system_site_packages
+
+        if python_config is None:
+            python_config = {}
+        self.system_site_packages = python_config.get('use_system_site_packages', False)
+        self.python_version = python_config.get('version', '2.7')
+
         self.setup()
 
     def python_run(self, command_bin, args):
@@ -35,7 +40,7 @@ class VirtualEnv(object):
         params = [
             'virtualenv',
             self.base_path,
-            '--python=/usr/bin/python2.7',
+            '--python=/usr/bin/python{}'.format(self.python_version),
         ]
         if self.system_site_packages:
             params.append('--system-site-packages')


### PR DESCRIPTION
actually use the `version` field of the configuration to build the virtualenv.

also, small refactoring to give directly the `python_config` to `VirtualEnv`
