### PR TITLE
Add new option to allow override pdflatex binary

### DIFF
--- a/readthedocs_build/config/config.py
+++ b/readthedocs_build/config/config.py
@@ -155,6 +155,8 @@ class BuildConfig(dict):
         self.validate_requirements_file()
         self.validate_conf_file()
 
+        self.validate_pdflatex()
+
     def validate_output_base(self):
         assert 'output_base' in self.env_config, (
                '"output_base" required in "env_config"')
@@ -290,6 +292,13 @@ class BuildConfig(dict):
                         raw_conda['file'], base_path)
 
             self['conda'] = conda
+
+    def validate_pdflatex(self):
+        if 'pdflatex' not in self.raw_config:
+            self['pdflatex'] = validate_string('pdflatex')
+        else:
+            with self.catch_validation_error('pdflatex'):
+                self['pdflatex'] = validate_string(self.raw_config['pdflatex'])
 
     def validate_requirements_file(self):
         if 'requirements_file' not in self.raw_config:

--- a/readthedocs_build/config/config.py
+++ b/readthedocs_build/config/config.py
@@ -295,7 +295,7 @@ class BuildConfig(dict):
 
     def validate_pdflatex(self):
         if 'pdflatex' not in self.raw_config:
-            self['pdflatex'] = validate_string('pdflatex')
+            self['pdflatex'] = 'pdflatex'
         else:
             with self.catch_validation_error('pdflatex'):
                 self['pdflatex'] = validate_string(self.raw_config['pdflatex'])

--- a/readthedocs_build/config/test_config.py
+++ b/readthedocs_build/config/test_config.py
@@ -204,6 +204,25 @@ def describe_validate_python_extra_requirements():
         validate_string.assert_any_call('tests')
 
 
+def describe_validate_pdflatex():
+    def it_defaults_to_pdflatex():
+        build = get_build_config({'python': {}})
+        build.validate_pdflatex()
+        assert build['pdflatex'] == 'pdflatex'
+
+    def it_validates_is_a_string():
+        build = get_build_config({'pdflatex': ['invalid']})
+        with raises(InvalidConfig) as excinfo:
+            build.validate_pdflatex()
+        assert excinfo.value.key == 'pdflatex'
+        assert excinfo.value.code == INVALID_STRING
+
+    def it_gets_set_correctly():
+        build = get_build_config({'pdflatex': 'xelatex'})
+        build.validate_pdflatex()
+        assert build['pdflatex'] == 'xelatex'
+
+
 def describe_validate_use_system_site_packages():
     def it_defaults_to_false():
         build = get_build_config({'python': {}})


### PR DESCRIPTION
Any pdflatex-compatible binary could be used instead.  For example, xelatex (as requested in rtfd/readthedocs.org#1556).

This is a very primitive version of that can be used to solve mentioned issue.  Some other variants are mentioned in the issue thread.
