### PR TITLE
Update sphinx to 1.5.1 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _readthedocs_build
 autoapi
 _build_rtd
 /.tox/
+.idea/

--- a/readthedocs_build/builder/sphinx.py
+++ b/readthedocs_build/builder/sphinx.py
@@ -12,7 +12,7 @@ class SphinxBuilder(BaseBuilder):
     """
 
     python_dependencies = BaseBuilder.python_dependencies + (
-        'Sphinx==1.5.1'
+        'Sphinx==1.5.1',
     )
 
     def _run_sphinx_build(self, format, out_dir):

--- a/readthedocs_build/builder/sphinx.py
+++ b/readthedocs_build/builder/sphinx.py
@@ -12,8 +12,7 @@ class SphinxBuilder(BaseBuilder):
     """
 
     python_dependencies = BaseBuilder.python_dependencies + (
-        'Sphinx>=1.3.1',
-        'Docutils==0.12'
+        'Sphinx==1.5.1'
     )
 
     def _run_sphinx_build(self, format, out_dir):

--- a/readthedocs_build/builder/sphinx.py
+++ b/readthedocs_build/builder/sphinx.py
@@ -12,7 +12,8 @@ class SphinxBuilder(BaseBuilder):
     """
 
     python_dependencies = BaseBuilder.python_dependencies + (
-        'Sphinx==1.3.1',
+        'Sphinx>=1.3.1',
+        'Docutils==0.12'
     )
 
     def _run_sphinx_build(self, format, out_dir):

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ setup(
     long_description=codecs.open("README.rst", "r", "utf-8").read(),
     install_requires=[
         "PyYAML>=3.0",
-        "Sphinx>=1.3",
-        "Docutils==0.12",
+        "Sphinx>=1.5",
+        "Docutils",
         "readthedocs-sphinx-ext",
         "recommonmark",
         "click>=4.0",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     install_requires=[
         "PyYAML>=3.0",
         "Sphinx>=1.3",
-        "Docutils",
+        "Docutils==0.12",
         "readthedocs-sphinx-ext",
         "recommonmark",
         "click>=4.0",


### PR DESCRIPTION
According to this issue https://github.com/sphinx-doc/sphinx/issues/3212, docutils 0.13.1 has caused our docs generation to fail. This updates the sphinx requirement to 1.5.1 and fix the issue.