### PR TITLE
Custom conda channels

### DIFF
--- a/readthedocs_build/config/config.py
+++ b/readthedocs_build/config/config.py
@@ -307,9 +307,11 @@ class BuildConfig(dict):
                         try:
                             validate_url(c)
                         except ValidationError:
-                            if c[0] == "/":
-                                # Leading slashes will be interpreted as paths
-                                # by conda
+                            # We want that one to fail.
+                            # Now let's check if the value is path-like.
+                            if c[0] in "./~":
+                                # Any of those characters will make conda
+                                # search the local file system, which is a no-go.
                                 self.error('conda.channels',
                                            self.CONDA_CHANNELS_INVALID_MESSAGE,
                                            code=CONDA_CHANNELS_INVALID)

--- a/readthedocs_build/config/config.py
+++ b/readthedocs_build/config/config.py
@@ -10,6 +10,7 @@ from .validation import validate_choice
 from .validation import validate_directory
 from .validation import validate_file
 from .validation import validate_string
+from .validation import validate_url
 from .validation import ValidationError
 
 
@@ -29,6 +30,7 @@ NAME_INVALID = 'name-invalid'
 CONF_FILE_REQUIRED = 'conf-file-required'
 TYPE_REQUIRED = 'type-required'
 PYTHON_INVALID = 'python-invalid'
+CONDA_CHANNELS_INVALID = 'conda-channel-invalid'
 
 
 class ConfigError(Exception):
@@ -77,6 +79,7 @@ class BuildConfig(dict):
     PYTHON_INVALID_MESSAGE = '"python" section must be a mapping.'
     PYTHON_EXTRA_REQUIREMENTS_INVALID_MESSAGE = (
         '"python.extra_requirements" section must be a list.')
+    CONDA_CHANNELS_INVALID_MESSAGE = 'conda channels must be a list of anaconda.org channels.'
 
     def __init__(self, env_config, raw_config, source_file, source_position):
         self.env_config = env_config
@@ -288,6 +291,32 @@ class BuildConfig(dict):
                     base_path = os.path.dirname(self.source_file)
                     conda['file'] = validate_file(
                         raw_conda['file'], base_path)
+
+            if 'channels' in raw_conda:
+                channels = raw_conda["channels"]
+                with self.catch_validation_error('conda.channels'):
+                    if not isinstance(channels, (list, tuple)):
+                        self.error('conda.channels',
+                                   self.CONDA_CHANNELS_INVALID_MESSAGE,
+                                   code=CONDA_CHANNELS_INVALID)
+                    for c in channels:
+                        # While conda supports arbitrary URLs for channels,
+                        # it's a massive rabbit hole to try and chase down
+                        # the "proper" security stance for that. Let's make it
+                        # easier and only allow normal anaconda.org channels.
+                        try:
+                            validate_url(c)
+                        except ValidationError:
+                            if c[0] == "/":
+                                # Leading slashes will be interpreted as paths
+                                # by conda
+                                self.error('conda.channels',
+                                           self.CONDA_CHANNELS_INVALID_MESSAGE,
+                                           code=CONDA_CHANNELS_INVALID)
+                        else:
+                            self.error('conda.channels',
+                                       self.CONDA_CHANNELS_INVALID_MESSAGE,
+                                       code=CONDA_CHANNELS_INVALID)
 
             self['conda'] = conda
 

--- a/readthedocs_build/config/test_validation.py
+++ b/readthedocs_build/config/test_validation.py
@@ -160,3 +160,4 @@ def describe_validate_url():
         with raises(ValidationError) as excinfo:
             validate_url("http:///test")
         assert excinfo.value.code == INVALID_URL
+        assert validate_url("file:///test") == "file:///test"

--- a/readthedocs_build/config/test_validation.py
+++ b/readthedocs_build/config/test_validation.py
@@ -9,6 +9,7 @@ from .validation import validate_directory
 from .validation import validate_file
 from .validation import validate_path
 from .validation import validate_string
+from .validation import validate_url
 from .validation import ValidationError
 from .validation import INVALID_BOOL
 from .validation import INVALID_CHOICE
@@ -16,6 +17,7 @@ from .validation import INVALID_DIRECTORY
 from .validation import INVALID_FILE
 from .validation import INVALID_PATH
 from .validation import INVALID_STRING
+from .validation import INVALID_URL
 
 
 def describe_validate_bool():
@@ -137,3 +139,24 @@ def describe_validate_string():
         with raises(ValidationError) as excinfo:
             validate_string(None)
         assert excinfo.value.code == INVALID_STRING
+
+
+def describe_validate_url():
+
+    def it_accepts_complex_urls():
+        result = validate_url("ftp://user:password@www.example.com/test?myvalue=test")
+        assert isinstance(result, basestring)
+
+    def it_accepts_simple_urls():
+        result = validate_url("http://www.example.com/")
+        assert isinstance(result, basestring)
+
+    def it_rejects_no_scheme():
+        with raises(ValidationError) as excinfo:
+            validate_url("www.example.com/test")
+        assert excinfo.value.code == INVALID_URL
+
+    def it_rejects_no_host():
+        with raises(ValidationError) as excinfo:
+            validate_url("http:///test")
+        assert excinfo.value.code == INVALID_URL

--- a/readthedocs_build/config/validation.py
+++ b/readthedocs_build/config/validation.py
@@ -82,6 +82,8 @@ def validate_url(value):
     parsed = urlparse.urlparse(string_value)
     if not parsed.scheme:
         raise ValidationError(value, INVALID_URL)
-    if not parsed.netloc:
-        raise ValidationError(value, INVALID_URL)
+    # Expand as necessary for schemes that allow no hostname
+    if parsed.scheme not in ["file"]:
+        if not parsed.netloc:
+            raise ValidationError(value, INVALID_URL)
     return string_value

--- a/readthedocs_build/config/validation.py
+++ b/readthedocs_build/config/validation.py
@@ -1,4 +1,5 @@
 import os
+import urlparse
 
 
 INVALID_BOOL = 'invalid-bool'
@@ -7,6 +8,7 @@ INVALID_DIRECTORY = 'invalid-directory'
 INVALID_FILE = 'invalid-file'
 INVALID_PATH = 'invalid-path'
 INVALID_STRING = 'invalid-string'
+INVALID_URL = 'invalid-url'
 
 
 class ValidationError(Exception):
@@ -17,6 +19,7 @@ class ValidationError(Exception):
         INVALID_FILE: '{value} is not a file',
         INVALID_PATH: 'path {value} does not exist',
         INVALID_STRING: 'expected string',
+        INVALID_URL: 'expected URL, received {value}',
     }
 
     def __init__(self, value, code, format_kwargs=None):
@@ -72,3 +75,13 @@ def validate_string(value):
     if not isinstance(value, basestring):
         raise ValidationError(value, INVALID_STRING)
     return unicode(value)
+
+
+def validate_url(value):
+    string_value = validate_string(value)
+    parsed = urlparse.urlparse(string_value)
+    if not parsed.scheme:
+        raise ValidationError(value, INVALID_URL)
+    if not parsed.netloc:
+        raise ValidationError(value, INVALID_URL)
+    return string_value


### PR DESCRIPTION
This goes with rtfd/readthedocs.org#2507.

That PR adds custom conda channel support to the config parser; this one adds validation for those config options. It also adds tests for the validation.

I'm intentionally curtailing some of the functionality of conda here. `conda -c $CHANNEL` has support for 3 different kinds of input; here's the relevant help section:

```
  -c CHANNEL, --channel CHANNEL
                        Additional channel to search for packages. These are
                        URLs searched in the order they are given (including
                        file:// for local directories). Then, the defaults or
                        channels from .condarc are searched (unless
                        --override-channels is given). You can use 'defaults'
                        to get the default packages for conda, and 'system' to
                        get the system packages, which also takes .condarc
                        into account. You can also use any name and the
                        .condarc channel_alias value will be prepended. The
                        default channel_alias is http://conda.anaconda.org/.
```

It seems like a needless security issue to provide any of the valid inputs as working options here.  Any time a system exposes its filesystem to open web handling I get itchy under the collar. So, I opted to limit valid channels to only being ones hosted at the `channel_alias` (`conda.anaconda.org`, presumably, though your deployment may vary). I did my best to tighten up the testing and validation on those checks, though I'm sure I missed something.