### PR TITLE
Extend support for Python version validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 language: python
 python:
- - 2.7
+  - 2.7
 sudo: false
 env:
- - TOX_ENV=py27-unittest
- - TOX_ENV=py27-integration
- - TOX_ENV=lint
- #- TOX_ENV=docs
+  - TOX_ENV=py27-unittest
+  - TOX_ENV=py27-integration
+  - TOX_ENV=lint
+  #- TOX_ENV=docs
 install:
- - pip install tox
+  - pip install tox
 script:
- - tox -e $TOX_ENV
+  - tox -e $TOX_ENV
 notifications:
   slack:
     rooms:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ This is a fine set of docs
    :glob:
 
    steps
+   spec
 
 
 

--- a/docs/spec.rst
+++ b/docs/spec.rst
@@ -149,6 +149,19 @@ Following mapping keys are supported (all but the marked once are optional):
         The path in which ``python setup.py install`` will be executed.
         Defaults to the repository root.
 
+    ``version``
+        The Python interpreter version to use for all build calls. This value
+        should be a float or integer value.
+
+        Supported versions can be configured on config instantiation by passing
+        in the following to the `env_config`::
+
+            {
+                'python': {
+                    'supported_versions': [2, 2.7, 3, 3.5],
+                }
+            }
+
 ``language``
     The language the doc is written in. Defaults to empty string.
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,2 +1,4 @@
 name: read-the-docs
 type: sphinx
+python:
+  version: 3.6

--- a/readthedocs_build/config/config.py
+++ b/readthedocs_build/config/config.py
@@ -114,9 +114,11 @@ class BuildConfig(dict):
             'sphinx',
         )
 
-    def get_valid_python_versions(self, supported_versions=None):
-        if supported_versions is not None:
-            return supported_versions
+    def get_valid_python_versions(self):
+        try:
+            return self.env_config['python']['supported_versions']
+        except (KeyError, TypeError):
+            pass
         return self.PYTHON_SUPPORTED_VERSIONS
 
     def get_valid_formats(self):
@@ -275,18 +277,9 @@ class BuildConfig(dict):
                                 version = float(version)
                             except ValueError:
                                 pass
-                    # Get Python version support from the env_conf, as we will
-                    # pass this in based on the build image being used
-                    supported_versions = None
-                    try:
-                        supported_versions = self.env_config['python']['supported_versions']
-                    except (KeyError, TypeError):
-                        pass
                     python['version'] = validate_choice(
                         version,
-                        self.get_valid_python_versions(
-                            supported_versions=supported_versions
-                        )
+                        self.get_valid_python_versions()
                     )
 
         self['python'] = python

--- a/readthedocs_build/config/test_validation.py
+++ b/readthedocs_build/config/test_validation.py
@@ -5,6 +5,7 @@ import os
 
 from .validation import validate_bool
 from .validation import validate_choice
+from .validation import validate_list
 from .validation import validate_directory
 from .validation import validate_file
 from .validation import validate_path
@@ -12,6 +13,7 @@ from .validation import validate_string
 from .validation import ValidationError
 from .validation import INVALID_BOOL
 from .validation import INVALID_CHOICE
+from .validation import INVALID_LIST
 from .validation import INVALID_DIRECTORY
 from .validation import INVALID_FILE
 from .validation import INVALID_PATH
@@ -43,13 +45,39 @@ def describe_validate_choice():
         result = validate_choice('choice', ('choice', 'another_choice'))
         assert result is 'choice'
 
-        result = validate_choice('c', 'abc')
-        assert result is 'c'
+        with raises(ValidationError) as excinfo:
+            validate_choice('c', 'abc')
+        assert excinfo.value.code == INVALID_LIST
 
     def it_rejects_invalid_choice():
         with raises(ValidationError) as excinfo:
             validate_choice('not-a-choice', ('choice', 'another_choice'))
         assert excinfo.value.code == INVALID_CHOICE
+
+
+def describe_validate_list():
+
+    def it_accepts_list_types():
+        result = validate_list(['choice', 'another_choice'])
+        assert result == ['choice', 'another_choice']
+
+        result = validate_list(('choice', 'another_choice'))
+        assert result == ['choice', 'another_choice']
+
+        def iterator():
+            yield 'choice'
+
+        result = validate_list(iterator())
+        assert result == ['choice']
+
+        with raises(ValidationError) as excinfo:
+            validate_choice('c', 'abc')
+        assert excinfo.value.code == INVALID_LIST
+
+    def it_rejects_string_types():
+        with raises(ValidationError) as excinfo:
+            result = validate_list('choice')
+        assert excinfo.value.code == INVALID_LIST
 
 
 def describe_validate_directory():

--- a/readthedocs_build/config/validation.py
+++ b/readthedocs_build/config/validation.py
@@ -3,6 +3,7 @@ import os
 
 INVALID_BOOL = 'invalid-bool'
 INVALID_CHOICE = 'invalid-choice'
+INVALID_LIST = 'invalid-list'
 INVALID_DIRECTORY = 'invalid-directory'
 INVALID_FILE = 'invalid-file'
 INVALID_PATH = 'invalid-path'
@@ -17,6 +18,7 @@ class ValidationError(Exception):
         INVALID_FILE: '{value} is not a file',
         INVALID_PATH: 'path {value} does not exist',
         INVALID_STRING: 'expected string',
+        INVALID_LIST: 'expected list',
     }
 
     def __init__(self, value, code, format_kwargs=None):
@@ -31,10 +33,19 @@ class ValidationError(Exception):
         super(ValidationError, self).__init__(message)
 
 
+def validate_list(value):
+    if isinstance(value, str):
+        raise ValidationError(value, INVALID_LIST)
+    if not hasattr(value, '__iter__'):
+        raise ValidationError(value, INVALID_LIST)
+    return list(value)
+
+
 def validate_choice(value, choices):
+    choices = validate_list(choices)
     if value not in choices:
         raise ValidationError(value, INVALID_CHOICE, {
-            'choices': ', '.join(choices)
+            'choices': ', '.join(map(str, choices))
         })
     return value
 


### PR DESCRIPTION
* Allow for python supported versions to be passed into the config object. This
  is required to pass in per-build environment python versions for validation
* More validation on lists
* Don't handle strings as iterables in choice validation
* Coerce Python verion to an int/float if possible

Refs rtfd/readthedocs-docker-images#18