### PR TITLE
Use topdown to sort find files

### DIFF
--- a/readthedocs_build/config/find.py
+++ b/readthedocs_build/config/find.py
@@ -3,7 +3,8 @@ import os
 
 def find_all(path, filenames):
     path = os.path.abspath(path)
-    for root, dirs, files in os.walk(path):
+    for root, dirs, files in os.walk(path, topdown=True):
+        dirs.sort()
         for filename in filenames:
             if filename in files:
                 yield os.path.abspath(os.path.join(root, filename))

--- a/tox.ini
+++ b/tox.ini
@@ -1,29 +1,21 @@
 [tox]
 envlist =
-    py{27,34,35,36}-unittest,
+    py{27,34,35,36}
     py{27,34,35,36}-integration
     lint
-    # docs
 
 [tox:travis]
-2.7 = py27-unittest, py27-integration, lint
-3.4 = py34-unittest, py34-integration
-3.5 = py35-unittest, py35-integration
-3.6 = py36-unittest, py36-integration
+2.7 = py27, py27-integration, lint
+3.4 = py34, py34-integration
+3.5 = py35, py35-integration
+3.6 = py36, py36-integration
 
 [testenv]
 deps =
     -r{toxinidir}/requirements/tests.txt
 commands =
-    py.test {posargs}
-
-[testenv:py27-integration]
-commands =
-    py.test integration_tests/ -s
-
-[testenv:py27-unittest]
-commands =
-    py.test readthedocs_build/
+    py.test readthedocs_build/ {posargs}
+    integration: py.test integration_tests/ -s
 
 [testenv:docs]
 changedir = {toxinidir}/docs


### PR DESCRIPTION
Because os.walk returns files in an arbitrary manner, sort dirs to ensure this
order. Also tunes up tox config more.

Fixes #22 