### PR TITLE
Added support for --process-dependency-links flag in pip

### DIFF
--- a/readthedocs_build/config/config.py
+++ b/readthedocs_build/config/config.py
@@ -210,6 +210,7 @@ class BuildConfig(dict):
             'use_system_site_packages': False,
             'pip_install': False,
             'extra_requirements': [],
+            'process_dependency_links': False,
             'setup_py_install': False,
             'setup_py_path': os.path.join(
                 os.path.dirname(self.source_file),
@@ -237,6 +238,12 @@ class BuildConfig(dict):
                 with self.catch_validation_error('python.pip_install'):
                     python['pip_install'] = validate_bool(
                         raw_python['pip_install'])
+
+            # Validate process_dependency_links.
+            if 'process_dependency_links' in raw_python:
+                with self.catch_validation_error('python.process_dependency_links'):
+                    python['process_dependency_links'] = validate_bool(
+                        raw_python['process_dependency_links'])
 
             # Validate extra_requirements.
             if 'extra_requirements' in raw_python:

--- a/readthedocs_build/config/test_config.py
+++ b/readthedocs_build/config/test_config.py
@@ -179,6 +179,13 @@ def test_python_pip_install_default():
     assert build['python']['pip_install'] is False
 
 
+def test_python_process_dependency_links_default():
+    build = get_build_config({'python': {}})
+    build.validate_python()
+    # Default is False.
+    assert build['python']['process_dependency_links'] is False
+
+
 def describe_validate_python_extra_requirements():
 
     def it_defaults_to_list():


### PR DESCRIPTION
Together with rtfd/readthedocs.org#3162, this allows the `--process-dependency-links` flag in pip to be used, allowing docs to be built even when dependencies include code from non-pypi sources such as GitHub.  This PR must be accepted first in order for the PR referenced above to pass.  See also rtfd/readthedocs.org#3156.  