### PR TITLE
Add the ability to add a docker config image

### DIFF
--- a/docs/spec.rst
+++ b/docs/spec.rst
@@ -105,6 +105,12 @@ Following mapping keys are supported (all but the marked once are optional):
     - ``pdf``, default: ``false``
     - ``epub``, default: ``false``
 
+``docker``
+  Options for setting the docker configuration.
+
+    ``image``
+    This sets the docker image to use on the build, as defined `here <https://github.com/rtfd/readthedocs-docker-images/blob/master/CONTRIBUTING.rst#releases>`_.
+
 ``python``
     Python specific configuration. All builds are executed inside a
     virtualenv. This config can customize the virtualenv before running the

--- a/docs/spec.rst
+++ b/docs/spec.rst
@@ -105,7 +105,7 @@ Following mapping keys are supported (all but the marked once are optional):
     - ``pdf``, default: ``false``
     - ``epub``, default: ``false``
 
-``docker``
+``build``
   Options for setting the docker configuration.
 
     ``image``

--- a/docs/spec.rst
+++ b/docs/spec.rst
@@ -109,7 +109,7 @@ Following mapping keys are supported (all but the marked once are optional):
   Options for setting the docker configuration.
 
     ``image``
-    This sets the docker image to use on the build, as defined `here <https://github.com/rtfd/readthedocs-docker-images/blob/master/CONTRIBUTING.rst#releases>`_.
+    This sets the build image to use on the build, as defined `here <https://github.com/rtfd/readthedocs-docker-images/blob/master/CONTRIBUTING.rst#releases>`_.
 
 ``python``
     Python specific configuration. All builds are executed inside a

--- a/readthedocs_build/config/config.py
+++ b/readthedocs_build/config/config.py
@@ -28,6 +28,8 @@ PYTHON_INVALID = 'python-invalid'
 
 DOCKER_DEFAULT_IMAGE = 'readthedocs/build'
 DOCKER_DEFAULT_VERSION = '2.0'
+# These map to coordisponding settings in the .org,
+# so they haven't been renamed.
 DOCKER_IMAGE = '{}:{}'.format(DOCKER_DEFAULT_IMAGE, DOCKER_DEFAULT_VERSION)
 DOCKER_IMAGE_SETTINGS = {
     'readthedocs/build:1.0': {
@@ -232,6 +234,9 @@ class BuildConfig(dict):
         * Then append the default _image_, since users can't change this
         * Then update the env_config with the settings for that specific image
            - This is currently used for a build image -> python version mapping
+
+        This means we can use custom docker _images_,
+        but can't change the supported _versions_ that users have defined.
         """
         # Defaults
         if 'build' in self.env_config:

--- a/readthedocs_build/config/config.py
+++ b/readthedocs_build/config/config.py
@@ -132,6 +132,13 @@ class BuildConfig(dict):
             'epub',
         )
 
+    def get_valid_python_versions(self):
+        try:
+            return self.env_config['python']['supported_versions']
+        except (KeyError, TypeError):
+            pass
+        return self.PYTHON_SUPPORTED_VERSIONS
+
     def validate(self):
         """
         Validate and process config into ``config`` attribute that contains the
@@ -221,11 +228,10 @@ class BuildConfig(dict):
                         str(_build['image']),
                         self.DOCKER_SUPPORTED_VERSIONS,
                     )
+            build['supported_python_versions'] = \
+                DOCKER_BUILD_IMAGES[build['image']]['python']['supported_versions']
         self['build'] = build
 
-        # Set the valid python versions for this container
-        img = build['image']
-        self.PYTHON_SUPPORTED_VERSIONS = DOCKER_BUILD_IMAGES[img]['python']['supported_versions']
 
     def validate_python(self):
         python = {

--- a/readthedocs_build/config/config.py
+++ b/readthedocs_build/config/config.py
@@ -125,6 +125,13 @@ class BuildConfig(dict):
             'sphinx',
         )
 
+    def get_valid_python_versions(self):
+        try:
+            return self.env_config['python']['supported_versions']
+        except (KeyError, TypeError):
+            pass
+        return self.PYTHON_SUPPORTED_VERSIONS
+
     def get_valid_formats(self):
         return (
             'none',
@@ -132,13 +139,6 @@ class BuildConfig(dict):
             'pdf',
             'epub',
         )
-
-    def get_valid_python_versions(self):
-        try:
-            return self.env_config['python']['supported_versions']
-        except (KeyError, TypeError):
-            pass
-        return self.PYTHON_SUPPORTED_VERSIONS
 
     def validate(self):
         """

--- a/readthedocs_build/config/config.py
+++ b/readthedocs_build/config/config.py
@@ -79,6 +79,7 @@ class BuildConfig(dict):
         '"python.extra_requirements" section must be a list.')
 
     PYTHON_SUPPORTED_VERSIONS = [2, 2.7, 3, 3.3, 3.4, 3.5, 3.6]
+    DOCKER_SUPPORTED_VERSIONS = ['1.0', '2.0', 'latest']
 
     def __init__(self, env_config, raw_config, source_file, source_position):
         self.env_config = env_config
@@ -204,6 +205,19 @@ class BuildConfig(dict):
             base_path = os.path.dirname(self.source_file)
             base = validate_directory(base, base_path)
         self['base'] = base
+
+    def validate_docker(self):
+        # Defaults
+        docker = {'image': '2.0'}
+        if 'docker' in self.raw_config:
+            _docker = self.raw_config['docker']
+            if 'image' in _docker:
+                with self.catch_validation_error('docker'):
+                    docker['image'] = validate_choice(
+                        str(_docker['image']),
+                        self.DOCKER_SUPPORTED_VERSIONS,
+                    )
+        self['docker'] = docker
 
     def validate_python(self):
         python = {

--- a/readthedocs_build/config/config.py
+++ b/readthedocs_build/config/config.py
@@ -224,9 +224,8 @@ class BuildConfig(dict):
         self['build'] = build
 
         # Set the valid python versions for this container
-
-        self.PYTHON_SUPPORTED_VERSIONS = \
-            DOCKER_BUILD_IMAGES[build['image']]['python']['supported_versions']
+        img = build['image']
+        self.PYTHON_SUPPORTED_VERSIONS = DOCKER_BUILD_IMAGES[img]['python']['supported_versions']
 
     def validate_python(self):
         python = {

--- a/readthedocs_build/config/config.py
+++ b/readthedocs_build/config/config.py
@@ -259,11 +259,11 @@ class BuildConfig(dict):
                     DOCKER_DEFAULT_IMAGE,
                     build['image']
                 )
-            if build['image'] in DOCKER_IMAGE_SETTINGS:
-                # Update docker settings from image name
-                self.env_config.update(
-                    DOCKER_IMAGE_SETTINGS[build['image']]
-                )
+        if build['image'] in DOCKER_IMAGE_SETTINGS:
+            # Update docker settings from image name
+            self.env_config.update(
+                DOCKER_IMAGE_SETTINGS[build['image']]
+            )
         self['build'] = build
 
     def validate_python(self):

--- a/readthedocs_build/config/config.py
+++ b/readthedocs_build/config/config.py
@@ -243,6 +243,7 @@ class BuildConfig(dict):
                     build['image']
                 )
             if build['image'] in DOCKER_IMAGE_SETTINGS:
+                # Update docker settings from image name
                 self.env_config.update(
                     DOCKER_IMAGE_SETTINGS[build['image']]
                 )

--- a/readthedocs_build/config/config.py
+++ b/readthedocs_build/config/config.py
@@ -259,10 +259,16 @@ class BuildConfig(dict):
                     DOCKER_DEFAULT_IMAGE,
                     build['image']
                 )
+        # Update docker default settings from image name
         if build['image'] in DOCKER_IMAGE_SETTINGS:
-            # Update docker settings from image name
             self.env_config.update(
                 DOCKER_IMAGE_SETTINGS[build['image']]
+            )
+        # Update docker settings from user config
+        if 'DOCKER_IMAGE_SETTINGS' in self.env_config and \
+                build['image'] in self.env_config['DOCKER_IMAGE_SETTINGS']:
+            self.env_config.update(
+                self.env_config['DOCKER_IMAGE_SETTINGS'][build['image']]
             )
         self['build'] = build
 

--- a/readthedocs_build/config/test_config.py
+++ b/readthedocs_build/config/test_config.py
@@ -281,6 +281,23 @@ def describe_validate_python_version():
         build.validate_python()
         assert build['python']['version'] == 3
 
+    def it_validates_env_supported_versions():
+        build = get_build_config(
+            {'python': {'version': 3.6}},
+            env_config={'python': {'supported_versions': [3.5]}}
+        )
+        with raises(InvalidConfig) as excinfo:
+            build.validate_python()
+        assert excinfo.value.key == 'python.version'
+        assert excinfo.value.code == INVALID_CHOICE
+
+        build = get_build_config(
+            {'python': {'version': 3.6}},
+            env_config={'python': {'supported_versions': [3.5, 3.6]}}
+        )
+        build.validate_python()
+        assert build['python']['version'] == 3.6
+
 
 def describe_validate_formats():
 

--- a/readthedocs_build/config/test_config.py
+++ b/readthedocs_build/config/test_config.py
@@ -413,6 +413,41 @@ def describe_validate_base():
         assert excinfo.value.code == INVALID_PATH
 
 
+def describe_validate_docker():
+
+    def it_fails_if_docker_is_invalid_option(tmpdir):
+        apply_fs(tmpdir, minimal_config)
+        build = BuildConfig(
+            {},
+            {'docker': {'image': 3.0}},
+            source_file=str(tmpdir.join('readthedocs.yml')),
+            source_position=0)
+        with raises(InvalidConfig) as excinfo:
+            build.validate_docker()
+        assert excinfo.value.key == 'docker'
+        assert excinfo.value.code == INVALID_CHOICE
+
+    def it_works(tmpdir):
+        apply_fs(tmpdir, minimal_config)
+        build = BuildConfig(
+            {},
+            {'docker': {'image': 'latest'}},
+            source_file=str(tmpdir.join('readthedocs.yml')),
+            source_position=0)
+        build.validate_docker()
+        assert build['docker']['image'] == 'latest'
+
+    def default(tmpdir):
+        apply_fs(tmpdir, minimal_config)
+        build = BuildConfig(
+            {},
+            {},
+            source_file=str(tmpdir.join('readthedocs.yml')),
+            source_position=0)
+        build.validate_docker()
+        assert build['docker']['image'] == '2.0'
+
+
 def test_build_validate_calls_all_subvalidators(tmpdir):
     apply_fs(tmpdir, minimal_config)
     build = BuildConfig(

--- a/readthedocs_build/config/test_config.py
+++ b/readthedocs_build/config/test_config.py
@@ -464,7 +464,7 @@ def describe_validate_build():
             source_file=str(tmpdir.join('readthedocs.yml')),
             source_position=0)
         build.validate_build()
-        assert build['build']['image'] == 'latest'
+        assert build['build']['image'] == 'readthedocs/build:latest'
 
     def default(tmpdir):
         apply_fs(tmpdir, minimal_config)
@@ -474,7 +474,7 @@ def describe_validate_build():
             source_file=str(tmpdir.join('readthedocs.yml')),
             source_position=0)
         build.validate_build()
-        assert build['build']['image'] == '2.0'
+        assert build['build']['image'] == 'readthedocs/build:2.0'
 
 
 def test_build_validate_calls_all_subvalidators(tmpdir):

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,5 +1,5 @@
 mock==1.3.0
-pytest>=2.7
+pytest==3.2.5
 pytest-describe==0.11.0
 pytest-xdist>=1.12
 tox>=2.1

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,5 +1,5 @@
 mock==1.3.0
 pytest>=2.7
-pytest-describe>=0.10.1
+pytest-describe==0.11.0
 pytest-xdist>=1.12
 tox>=2.1


### PR DESCRIPTION
This removes the old way of passing in the docker & python support info, and keeps it inside rtd-build. This is needed so we can verify the values the user has passed in for the docker image and python version are valid together!