### PR TITLE
Add isort configuration file

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,8 @@
+[settings]
+line_length=80
+indent='    '
+multi_line_output=4
+default_section=THIRDPARTY
+known_third_party=mock
+sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+add_imports=from __future__ import division, from __future__ import print_function, from __future__ import unicode_literals


### PR DESCRIPTION
Inspired by [rtd's configuration file](https://github.com/rtfd/readthedocs.org/blob/master/.isort.cfg).

This will help with the defaults imports for py2/py3 compatibility :)