### PR TITLE
Test for unicode path

### DIFF
--- a/readthedocs_build/config/test_find.py
+++ b/readthedocs_build/config/test_find.py
@@ -1,6 +1,6 @@
 import os
 
-from .find import find_all
+from .find import find_all, find_one
 from ..testing.utils import apply_fs
 
 
@@ -75,3 +75,15 @@ def test_find_multiple_files(tmpdir):
         str(tmpdir.join('first', 'readthedocs.yml')),
         str(tmpdir.join('third', 'readthedocs.yml')),
     ]
+
+
+def test_find_unicode_path(tmpdir):
+    base_path = os.path.abspath('integration_tests/bad_encode_project')
+    unicode_base_path = base_path  # .decode('utf-8')
+    try:
+        find_one(unicode_base_path, ('readthedocs.yml',))
+    except Exception as e:
+        __import__('pdb').set_trace()
+        assert isinstance(e, UnicodeDecodeError)
+    else:
+        assert False, 'No UnicodeDecodeError exception was raised'

--- a/readthedocs_build/config/test_find.py
+++ b/readthedocs_build/config/test_find.py
@@ -79,11 +79,14 @@ def test_find_multiple_files(tmpdir):
 
 def test_find_unicode_path(tmpdir):
     base_path = os.path.abspath('integration_tests/bad_encode_project')
-    unicode_base_path = base_path  # .decode('utf-8')
     try:
-        find_one(unicode_base_path, ('readthedocs.yml',))
+        path = find_one(base_path, ('readthedocs.yml',))
+        # When python3
+        assert path == ''
     except Exception as e:
-        __import__('pdb').set_trace()
+        # When python2
         assert isinstance(e, UnicodeDecodeError)
-    else:
-        assert False, 'No UnicodeDecodeError exception was raised'
+
+        unicode_base_path = base_path.decode('utf-8')
+        path = find_one(unicode_base_path, ('readthedocs.yml',))
+        assert path == ''

--- a/readthedocs_build/config/test_find.py
+++ b/readthedocs_build/config/test_find.py
@@ -1,5 +1,8 @@
 import os
 
+import pytest
+import six
+
 from .find import find_all, find_one
 from ..testing.utils import apply_fs
 
@@ -77,16 +80,11 @@ def test_find_multiple_files(tmpdir):
     ]
 
 
+@pytest.mark.skipif(not six.PY2, reason='Only for python2')
+@pytest.mark.xfail(raises=UnicodeDecodeError)
 def test_find_unicode_path(tmpdir):
     base_path = os.path.abspath('integration_tests/bad_encode_project')
-    try:
-        path = find_one(base_path, ('readthedocs.yml',))
-        # When python3
-        assert path == ''
-    except Exception as e:
-        # When python2
-        assert isinstance(e, UnicodeDecodeError)
-
-        unicode_base_path = base_path.decode('utf-8')
-        path = find_one(unicode_base_path, ('readthedocs.yml',))
-        assert path == ''
+    unicode_base_path = base_path.decode('utf-8')
+    path = find_one(unicode_base_path, ('readthedocs.yml',))
+    assert path == ''
+    assert False, 'The UnicodeDecodeError was not raised'

--- a/readthedocs_build/config/test_find.py
+++ b/readthedocs_build/config/test_find.py
@@ -84,7 +84,9 @@ def test_find_multiple_files(tmpdir):
 @pytest.mark.xfail(raises=UnicodeDecodeError)
 def test_find_unicode_path(tmpdir):
     base_path = os.path.abspath('integration_tests/bad_encode_project')
+    assert isinstance(base_path, str)
     unicode_base_path = base_path.decode('utf-8')
+    assert isinstance(unicode_base_path, unicode)
     path = find_one(unicode_base_path, ('readthedocs.yml',))
     assert path == ''
     assert False, 'The UnicodeDecodeError was not raised'


### PR DESCRIPTION
Test to expose fix for #27

This test was a little hard to figure out how to do it, since I wasn't able to use the name on the `py` file, so I had to add an actual file (I take the file from https://github.com/rtfd/readthedocs.org/issues/3732#issuecomment-370650285) and I had to made it py2 and py3 compatible. Please let me know if there is a better way.