### PR TITLE
Add submodule configuration

### DIFF
--- a/readthedocs_build/config/config.py
+++ b/readthedocs_build/config/config.py
@@ -446,8 +446,12 @@ class BuildConfig(dict):
         elif 'exclude' in raw_submodules:
             with self.catch_validation_error('submodules.exclude'):
                 exclude = raw_submodules['exclude']
-                submodules['exclude'] = validate_list(exclude)
-                self.validate_directories(submodules['exclude'])
+                if exclude == ALL:
+                    submodules['exclude'] = ALL
+                    submodules['recursive'] = False
+                else:
+                    submodules['exclude'] = validate_list(exclude)
+                    self.validate_directories(submodules['exclude'])
         elif submodules['recursive'] is True:
             self.error(
                 'submodules',

--- a/readthedocs_build/config/config.py
+++ b/readthedocs_build/config/config.py
@@ -6,7 +6,8 @@ from .find import find_one
 from .parser import ParseError
 from .parser import parse
 from .validation import (validate_bool, validate_choice, validate_directory,
-                         validate_file, validate_string, ValidationError)
+                         validate_file, validate_list, validate_string,
+                         ValidationError)
 
 
 __all__ = (
@@ -14,11 +15,14 @@ __all__ = (
 
 
 CONFIG_FILENAMES = ('readthedocs.yml', '.readthedocs.yml')
+ALL = 'all'
 
 
 BASE_INVALID = 'base-invalid'
 BASE_NOT_A_DIR = 'base-not-a-directory'
 CONFIG_SYNTAX_INVALID = 'config-syntax-invalid'
+INVALID_KEYS_COMBINATION = 'invalid-keys-combination'
+MISSING_REQUIRED_KEY = 'missing-required-key'
 CONFIG_REQUIRED = 'config-required'
 NAME_REQUIRED = 'name-required'
 NAME_INVALID = 'name-invalid'
@@ -168,6 +172,7 @@ class BuildConfig(dict):
         self.validate_base()
         self.validate_python()
         self.validate_formats()
+        self.validate_submodules()
 
         self.validate_conda()
         self.validate_requirements_file()
@@ -407,6 +412,62 @@ class BuildConfig(dict):
         self['formats'] = _formats
 
         return True
+
+    def validate_submodules(self):
+        raw_submodules = self.raw_config.get('submodules')
+        if raw_submodules is None:
+            self['submodules'] = self.get_default_submodules_config()
+            return None
+
+        if 'include' in raw_submodules and 'exclude' in raw_submodules:
+            self.error(
+                'submodules',
+                'It is not possible to include and exclude submodules',
+                code=INVALID_KEYS_COMBINATION
+            )
+
+        self['submodules'] = {}
+        submodules = self['submodules']
+
+        with self.catch_validation_error('submodules.recursive'):
+            recursive = raw_submodules.get('recursive', False)
+            submodules['recursive'] = validate_bool(recursive)
+
+        if 'include' in raw_submodules:
+            with self.catch_validation_error('submodules.include'):
+                include = raw_submodules['include']
+                if include == ALL:
+                    submodules['include'] = ALL
+                else:
+                    submodules['include'] = validate_list(include)
+                    self.validate_directories(submodules['include'])
+                if not submodules['include']:
+                    submodules['recursive'] = False
+        elif 'exclude' in raw_submodules:
+            with self.catch_validation_error('submodules.exclude'):
+                exclude = raw_submodules['exclude']
+                submodules['exclude'] = validate_list(exclude)
+                self.validate_directories(submodules['exclude'])
+        elif submodules['recursive'] is True:
+            self.error(
+                'submodules',
+                'You need to include submodules',
+                code=MISSING_REQUIRED_KEY
+            )
+        return True
+
+    def get_default_submodules_config(self):
+        return {
+            'include': [],
+            'recursive': False,
+        }
+
+    def validate_directories(self, directories):
+        base_path = os.path.dirname(self.source_file)
+        return [
+            validate_directory(directory, base_path)
+            for directory in directories
+        ]
 
 
 class ProjectConfig(list):

--- a/readthedocs_build/config/test_config.py
+++ b/readthedocs_build/config/test_config.py
@@ -9,6 +9,9 @@ from .config import InvalidConfig
 from .config import load
 from .config import BuildConfig
 from .config import ProjectConfig
+from .config import ALL
+from .config import INVALID_KEYS_COMBINATION
+from .config import MISSING_REQUIRED_KEY
 from .config import TYPE_REQUIRED
 from .config import NAME_REQUIRED
 from .config import NAME_INVALID
@@ -16,6 +19,7 @@ from .config import PYTHON_INVALID
 from .validation import INVALID_BOOL
 from .validation import INVALID_CHOICE
 from .validation import INVALID_DIRECTORY
+from .validation import INVALID_LIST
 from .validation import INVALID_PATH
 from .validation import INVALID_STRING
 
@@ -358,10 +362,8 @@ def describe_validate_submodules():
             build.validate_submodules()
             # TODO: This will be the dafult behavior?
             assert 'submodules' in build
-            assert build['submodules'] == {
-                'include': [],
-                'recursive': False,
-            }
+            assert build['submodules']['include'] == []
+            assert build['submodules']['recursive'] is False
 
     def it_parses_include_key(tmpdir):
         apply_fs(tmpdir, {'sub-one': {}, 'sub-two': {}})
@@ -446,8 +448,8 @@ def describe_validate_submodules():
             build = get_build_config({
                 'submodules': {
                     'exclude': ['sub-two'],
+                    'recursive': True,
                 },
-                'recursive': True,
             })
             build.validate_submodules()
             assert build['submodules']['recursive'] is True
@@ -458,8 +460,8 @@ def describe_validate_submodules():
             build = get_build_config({
                 'submodules': {
                     'exclude': ['sub-two'],
+                    'recursive': 'True',
                 },
-                'recursive': 'True',
             })
             with raises(InvalidConfig) as excinfo:
                 build.validate_submodules()
@@ -472,8 +474,8 @@ def describe_validate_submodules():
             build = get_build_config({
                 'submodules': {
                     'include': 'all',
+                    'recursive': True,
                 },
-                'recursive': True
             })
             build.validate_submodules()
             assert build['submodules']['include'] == ALL
@@ -485,8 +487,8 @@ def describe_validate_submodules():
             build = get_build_config({
                 'submodules': {
                     'include': 'none',
+                    'recursive': True,
                 },
-                'recursive': True
             })
             with raises(InvalidConfig) as excinfo:
                 build.validate_submodules()
@@ -499,8 +501,8 @@ def describe_validate_submodules():
             build = get_build_config({
                 'submodules': {
                     'exclude': 'all',
+                    'recursive': True,
                 },
-                'recursive': True
             })
             with raises(InvalidConfig) as excinfo:
                 build.validate_submodules()

--- a/readthedocs_build/config/test_config.py
+++ b/readthedocs_build/config/test_config.py
@@ -507,6 +507,34 @@ def describe_validate_submodules():
             assert excinfo.value.key == 'submodules.exclude'
             assert excinfo.value.code == INVALID_LIST
 
+    def it_parses_explicit_defaults(tmpdir):
+        apply_fs(tmpdir, {'sub-one': {}, 'sub-two': {}})
+        with tmpdir.as_cwd():
+            build = get_build_config({
+                'submodules': {
+                    'include': [],
+                    'recursive': False,
+                }
+            })
+            build.validate_submodules()
+            assert 'submodules' in build
+            assert build['submodules']['include'] == []
+            assert build['submodules']['recursive'] is False
+
+    def it_parses_explicit_wrong_defaults(tmpdir):
+        apply_fs(tmpdir, {'sub-one': {}, 'sub-two': {}})
+        with tmpdir.as_cwd():
+            build = get_build_config({
+                'submodules': {
+                    'include': [],
+                    'recursive': True,
+                }
+            })
+            build.validate_submodules()
+            assert 'submodules' in build
+            assert build['submodules']['include'] == []
+            assert build['submodules']['recursive'] is False
+
 
 def test_valid_build_config():
     build = BuildConfig(env_config,

--- a/readthedocs_build/config/test_config.py
+++ b/readthedocs_build/config/test_config.py
@@ -495,12 +495,25 @@ def describe_validate_submodules():
             assert excinfo.value.key == 'submodules.include'
             assert excinfo.value.code == INVALID_LIST
 
-    def it_validates_the_correct_type_for_exclude(tmpdir):
+    def it_accepts_all_keyword_on_exclude(tmpdir):
         apply_fs(tmpdir, {'sub-one': {}, 'sub-two': {}})
         with tmpdir.as_cwd():
             build = get_build_config({
                 'submodules': {
                     'exclude': 'all',
+                    'recursive': True,
+                },
+            })
+            build.validate_submodules()
+            assert build['submodules']['exclude'] == ALL
+            assert build['submodules']['recursive'] is False
+
+    def it_validates_the_correct_type_for_exclude(tmpdir):
+        apply_fs(tmpdir, {'sub-one': {}, 'sub-two': {}})
+        with tmpdir.as_cwd():
+            build = get_build_config({
+                'submodules': {
+                    'exclude': 'none',
                     'recursive': True,
                 },
             })


### PR DESCRIPTION
Closes #30 and probably also closes others issues on the rtd repo.

~~I'm adding only tests for now~~, hope the behavior for submodules is fine.

The checklist:

- [x] Add test for config
- [ ] Add _integration_ tests (that integrates with the others configs for now, the real integration would be on the rtd repo, right? or should I write one here?)
- [x] Implement the submodules validation
- [ ] Update the spec documentation (is it necessary to do it here or maybe just update https://docs.readthedocs.io/en/latest/yaml-config.html?)