### PR TITLE
 Travis CI: Drop the EOLed Python 3.4 and add 3.7 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
+dist: xenial  # required for Python >= 3.7
 python:
   - 2.7
-  - 3.4
   - 3.5
   - 3.6
-sudo: false
+  - 3.7
 install:
   - pip install tox-travis
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 [tox]
 envlist =
-    py{27,34,35,36}
-    py{27,34,35,36}-integration
+    py{27,35,36,37}
+    py{27,35,36,37}-integration
     lint
 
 [tox:travis]
 2.7 = py27, py27-integration, lint
-3.4 = py34, py34-integration
 3.5 = py35, py35-integration
 3.6 = py36, py36-integration
+3.7 = py37, py37-integration
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.4 is EOL  https://devguide.python.org/devcycle/#end-of-life-branches

Also, [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo: false__ in your __.travis.yml__, we recommend removing that configuration_"